### PR TITLE
Allow optional bin file to be exposed.

### DIFF
--- a/lib/pdftohtml.js
+++ b/lib/pdftohtml.js
@@ -108,7 +108,7 @@ function pdftohtml (filename, outfile, options) {
 }
 
 // module exports
-exports = module.exports = function(filename, args) {
-  return new pdftohtml(filename, args);
+exports = module.exports = function(filename, outfile, options) {
+  return new pdftohtml(filename, outfile, options);
 };
 


### PR DESCRIPTION
Hey, Great project! Just ran into some difficulties with using the new `bin` option and wanted to share what I did to fix the issue.

You updated the `pdftohtml` function but did not update the `exports` member for the node module. In other words, you updated the internals of the library to make us of the new `bin` option, but did not update the public api to use it. 

Thanks,

Jeremy