### PR TITLE
README: Add requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 pdftohtmljs provides access to [pdf2htmlEX](https://github.com/coolwanglu/pdf2htmlEX) via shell in node.js programs.
 
+## Requirements
+
+- [pdf2htmlEX](https://github.com/coolwanglu/pdf2htmlEX)
+
 ### Installation
 via npm:
 


### PR DESCRIPTION
Document pdf2htmlEX package dependency to avoid issues like https://github.com/fagbokforlaget/pdftohtmljs/issues/18 and https://github.com/fagbokforlaget/pdftohtmljs/issues/20.