### PR TITLE
Reject error with string message

### DIFF
--- a/lib/pdftohtml.js
+++ b/lib/pdftohtml.js
@@ -94,7 +94,7 @@ function pdftohtml (filename, outfile, options) {
         if (code === 0) {
           resolve(error);
         } else {
-          reject(new Error({code: code, msg:`${self.options.bin} returned an error.`, params: self.options.additional}));
+          reject(new Error(`${error}\n${self.options.bin} returned ${code}. Run with parameters: ${self.options.additional.join(' ')}`));
         }
       });
     });


### PR DESCRIPTION
The error was being created with custom properties, which would not display any explicit details nor allow the user to trace the reason.

Closes https://github.com/fagbokforlaget/pdftohtmljs/issues/24.